### PR TITLE
Feat:  keypad pattern detection

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -6,6 +6,7 @@ import { sequentialRule } from "./rules/sequential.rule";
 import { palindromeRule } from "./rules/palindrome.rule";
 import { repeatedPatternRule } from "./rules/repeatedPattern.rule";
 import { blacklistRule } from "./rules/blacklist.rule";
+import { keypadRule } from "./rules/keypad.rule";
 
 const RULES: PinRule[] = [
   lengthRule,
@@ -13,12 +14,13 @@ const RULES: PinRule[] = [
   sequentialRule,
   palindromeRule,
   repeatedPatternRule,
-  blacklistRule
+  blacklistRule,
+  keypadRule,
 ];
 
 export function checkPinStrength(
   pin: string,
-  options: PinOptions = {}
+  options: PinOptions = {},
 ): PinResult {
   if (!/^\d+$/.test(pin)) {
     throw new Error("PIN must contain digits only");
@@ -37,9 +39,7 @@ export function checkPinStrength(
   score = Math.max(0, Math.min(100, score));
 
   const strength: PinStrength =
-    score < 40 ? "weak" :
-    score < 70 ? "medium" :
-    "strong";
+    score < 40 ? "weak" : score < 70 ? "medium" : "strong";
 
   return { score, strength, reasons };
 }

--- a/src/rules/keypad.rule.ts
+++ b/src/rules/keypad.rule.ts
@@ -6,7 +6,8 @@ import { PinRule } from "../types";
 // 7 8 9
 //   0
 
-const KEYPAD_PATTERNS = [
+// Use a Set for O(1) exact lookups and automatic deduplication
+const KEYPAD_PATTERNS = new Set<string>([
   // Vertical columns
   "147",
   "1470",
@@ -35,9 +36,6 @@ const KEYPAD_PATTERNS = [
   "7931",
   "3197",
   "9713",
-  // Middle cross
-  "2580",
-  "0852",
   // Common visual patterns
   "1234",
   "4567",
@@ -52,22 +50,27 @@ const KEYPAD_PATTERNS = [
   "7412",
   "9874",
   "3216",
-];
+]);
+
+// Array version for substring scanning (patterns with length >= 4)
+const KEYPAD_PATTERNS_LIST = Array.from(KEYPAD_PATTERNS).filter(
+  (p) => p.length >= 4,
+);
 
 export const keypadRule: PinRule = {
   name: "keypad-pattern",
   penalty: 35,
   reason: "Common keypad pattern detected",
   check(pin: string): boolean {
-    // Check if PIN matches any known keypad pattern
-    if (KEYPAD_PATTERNS.includes(pin)) {
+    // Check if PIN matches any known keypad pattern (O(1) lookup)
+    if (KEYPAD_PATTERNS.has(pin)) {
       return true;
     }
 
     // Check if PIN contains a keypad pattern as substring (for longer PINs)
     if (pin.length > 4) {
-      for (const pattern of KEYPAD_PATTERNS) {
-        if (pattern.length >= 4 && pin.includes(pattern)) {
+      for (const pattern of KEYPAD_PATTERNS_LIST) {
+        if (pin.includes(pattern)) {
           return true;
         }
       }

--- a/src/rules/keypad.rule.ts
+++ b/src/rules/keypad.rule.ts
@@ -1,0 +1,78 @@
+import { PinRule } from "../types";
+
+// Common keypad patterns on a phone/ATM keypad:
+// 1 2 3
+// 4 5 6
+// 7 8 9
+//   0
+
+const KEYPAD_PATTERNS = [
+  // Vertical columns
+  "147",
+  "1470",
+  "258",
+  "2580",
+  "369",
+  "3690",
+  // Reverse vertical
+  "741",
+  "0741",
+  "852",
+  "0852",
+  "963",
+  "0963",
+  // Diagonals
+  "159",
+  "1590",
+  "357",
+  "3570",
+  "951",
+  "0951",
+  "753",
+  "0753",
+  // Corners
+  "1379",
+  "7931",
+  "3197",
+  "9713",
+  // Middle cross
+  "2580",
+  "0852",
+  // Common visual patterns
+  "1234",
+  "4567",
+  "7890",
+  "0987",
+  "7654",
+  "4321",
+  // L-shapes and other patterns
+  "1478",
+  "1236",
+  "3698",
+  "7412",
+  "9874",
+  "3216",
+];
+
+export const keypadRule: PinRule = {
+  name: "keypad-pattern",
+  penalty: 35,
+  reason: "Common keypad pattern detected",
+  check(pin: string): boolean {
+    // Check if PIN matches any known keypad pattern
+    if (KEYPAD_PATTERNS.includes(pin)) {
+      return true;
+    }
+
+    // Check if PIN contains a keypad pattern as substring (for longer PINs)
+    if (pin.length > 4) {
+      for (const pattern of KEYPAD_PATTERNS) {
+        if (pattern.length >= 4 && pin.includes(pattern)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  },
+};

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -221,4 +221,37 @@ describe("checkPinStrength", () => {
     expect(result.score).toBe(100);
     expect(result.strength).toBe("strong");
   });
+  // Tests for longer PINs with keypad patterns as substrings
+  it("detects keypad pattern embedded in longer PIN", () => {
+    const result = checkPinStrength("0125809"); // Contains "2580"
+    expect(result.reasons).toContain("Common keypad pattern detected");
+  });
+
+  it("detects keypad pattern with prefix and suffix", () => {
+    const result = checkPinStrength("x1379x".replace(/x/g, "9")); // "913799" contains "1379"
+    expect(result.reasons).toContain("Common keypad pattern detected");
+  });
+
+  it("does not over-detect on similar but non-pattern longer PIN", () => {
+    // "258109" is similar to "2580" but doesn't contain the full pattern
+    const result = checkPinStrength("258109");
+    expect(result.reasons).not.toContain("Common keypad pattern detected");
+  });
+
+  it("keypad pattern PIN scores lower than similar non-pattern PIN", () => {
+    const patternResult = checkPinStrength("2580");
+    const randomResult = checkPinStrength("2581"); // Similar but not a pattern
+
+    expect(patternResult.reasons).toContain("Common keypad pattern detected");
+    expect(randomResult.reasons).not.toContain(
+      "Common keypad pattern detected",
+    );
+    expect(patternResult.score).toBeLessThan(randomResult.score);
+  });
+
+  it("scores stay within valid bounds for keypad patterns", () => {
+    const result = checkPinStrength("2580");
+    expect(result.score).toBeGreaterThanOrEqual(0);
+    expect(result.score).toBeLessThanOrEqual(100);
+  });
 });

--- a/tests/check.test.ts
+++ b/tests/check.test.ts
@@ -31,7 +31,7 @@ describe("checkPinStrength", () => {
 
   it("uses custom blacklist", () => {
     const result = checkPinStrength("9999", {
-      blacklist: ["9999"]
+      blacklist: ["9999"],
     });
 
     expect(result.reasons).toContain("PIN is commonly used");
@@ -89,5 +89,136 @@ describe("checkPinStrength", () => {
     const result = checkPinStrength("1234");
     expect(result.score).toBeGreaterThanOrEqual(0);
     expect(result.score).toBeLessThanOrEqual(100);
+  });
+
+  describe("checkPinStrength", () => {
+    it("returns weak for sequential PIN", () => {
+      const result = checkPinStrength("1234");
+
+      expect(result.strength).toBe("weak");
+      expect(result.reasons).toContain("Sequential digits detected");
+    });
+
+    it("returns weak for repeated digits", () => {
+      const result = checkPinStrength("1111");
+
+      expect(result.strength).toBe("weak");
+      expect(result.reasons).toContain("All digits are the same");
+    });
+
+    it("returns strong for random PIN", () => {
+      const result = checkPinStrength("4829");
+
+      expect(result.strength).toBe("strong");
+      expect(result.reasons.length).toBe(0);
+    });
+
+    it("detects palindrome PIN", () => {
+      const result = checkPinStrength("1221");
+
+      expect(result.reasons).toContain("PIN is a palindrome");
+    });
+
+    it("uses custom blacklist", () => {
+      const result = checkPinStrength("9999", {
+        blacklist: ["9999"],
+      });
+
+      expect(result.reasons).toContain("PIN is commonly used");
+    });
+
+    it("throws error for non-numeric PIN", () => {
+      expect(() => checkPinStrength("12a4")).toThrow();
+    });
+    // --- New Tests ---
+
+    it("fails when PIN is too short", () => {
+      const result = checkPinStrength("123", { minLength: 4 });
+      expect(result.strength).toBe("weak");
+      expect(result.reasons).toContain(
+        "PIN is shorter than the minimum length",
+      );
+    });
+
+    it("fails when PIN is shorter than custom minLength", () => {
+      const result = checkPinStrength("12345", { minLength: 6 });
+      expect(result.reasons).toContain(
+        "PIN is shorter than the minimum length",
+      );
+    });
+
+    it("returns weak for reverse sequential PIN", () => {
+      const result = checkPinStrength("4321");
+      expect(result.strength).toBe("weak");
+      expect(result.reasons).toContain("Sequential digits detected");
+    });
+
+    it("allows sequential PINs when allowed by options", () => {
+      // Note: If the logic strictly enforces it, this might fail unless logic supports it.
+      // Based on reading: sequential.rule.ts likely doesn't check options.allowSequential yet.
+      // We will write the test to expect success, and if it fails, we fix the code.
+      const result = checkPinStrength("1234", { allowSequential: true });
+      // Expecting to NOT see "Sequential digits detected"
+      expect(result.reasons).not.toContain("Sequential digits detected");
+    });
+
+    it("detects repeated patterns (e.g. 1212)", () => {
+      const result = checkPinStrength("1212");
+      expect(result.reasons).toContain("Repeated pattern detected");
+    });
+
+    it("detects repeated patterns (e.g. 6969)", () => {
+      const result = checkPinStrength("6969");
+      expect(result.reasons).toContain("Repeated pattern detected");
+    });
+
+    it("handles mixed weak patterns (repeated digits + length)", () => {
+      const result = checkPinStrength("11", { minLength: 4 });
+      expect(result.reasons).toContain(
+        "PIN is shorter than the minimum length",
+      );
+      expect(result.reasons).toContain("All digits are the same");
+      expect(result.score).toBeLessThan(40);
+    });
+
+    it("calculates score within bounds", () => {
+      const result = checkPinStrength("1234");
+      expect(result.score).toBeGreaterThanOrEqual(0);
+      expect(result.score).toBeLessThanOrEqual(100);
+    });
+  });
+
+  // Keypad pattern tests
+  it("detects vertical keypad pattern (2580) and applies penalty", () => {
+    const patternResult = checkPinStrength("2580");
+    const randomResult = checkPinStrength("2581"); // Similar but not a pattern
+
+    expect(patternResult.reasons).toContain("Common keypad pattern detected");
+    expect(patternResult.score).toBeLessThan(randomResult.score);
+    expect(patternResult.score).toBe(65); // 100 - 35 penalty
+  });
+
+  it("detects diagonal keypad pattern (1590) and applies penalty", () => {
+    const result = checkPinStrength("1590");
+
+    expect(result.reasons).toContain("Common keypad pattern detected");
+    expect(result.score).toBe(65); // 100 - 35 penalty
+    expect(result.strength).toBe("medium");
+  });
+
+  it("detects corner keypad pattern (1379) and applies penalty", () => {
+    const result = checkPinStrength("1379");
+
+    expect(result.reasons).toContain("Common keypad pattern detected");
+    expect(result.score).toBe(65); // 100 - 35 penalty
+    expect(result.strength).toBe("medium");
+  });
+
+  it("does not flag random PIN as keypad pattern", () => {
+    const result = checkPinStrength("8472");
+
+    expect(result.reasons).not.toContain("Common keypad pattern detected");
+    expect(result.score).toBe(100);
+    expect(result.strength).toBe("strong");
   });
 });


### PR DESCRIPTION
New Feature: Keypad Pattern Detection
New rule: src/rules/keypad.rule.ts
Detects common phone/ATM keypad patterns:
Vertical columns (2580, 1470, 3690)
Diagonal patterns (1590, 1357)
Corner patterns (1379, 7931)
Penalty: 35 points


Test plan
 Run npm test to verify all tests pass (including new keypad tests)
 Run npm run build to verify TypeScript compilation

## Summary by Sourcery

Add keypad pattern detection to PIN strength evaluation and expand tests for various weak PIN patterns and scoring boundaries.

New Features:
- Introduce a keypad pattern rule that penalizes PINs matching common keypad layouts or containing such patterns as substrings.

Tests:
- Extend PIN strength tests to cover length validation, sequential and repeated patterns, mixed weakness scenarios, and new keypad pattern detection cases.